### PR TITLE
feat: 주간 ai 인사이트 분석

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
             sudo pkill -f "java -jar" || true # 기존 애플리케이션 종료
           
             # 새 애플리케이션 시작 (환경 변수 적용)
-            nohup java -jar -Dspring.profiles.active=prod -Dspring.datasource.url=jdbc:postgresql://${{ secrets.DB_HOST }}:${{ vars.DB_PORT }}/${{ secrets.DB_NAME }} -Dspring.datasource.username=${{ secrets.DB_USERNAME }} -Dspring.datasource.password=${{ secrets.DB_PASSWORD }} -DJWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} ~/habiglow-0.0.1-SNAPSHOT.jar > ~/nohup.out 2>&1 &
+            nohup java -jar -Dspring.profiles.active=prod -Dspring.datasource.url=jdbc:postgresql://${{ secrets.DB_HOST }}:${{ vars.DB_PORT }}/${{ secrets.DB_NAME }} -Dspring.datasource.username=${{ secrets.DB_USERNAME }} -Dspring.datasource.password=${{ secrets.DB_PASSWORD }} -DJWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }} -DOPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} ~/habiglow-0.0.1-SNAPSHOT.jar > ~/nohup.out 2>&1 &
           
             # Nginx 재시작
             sudo systemctl restart nginx

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ dependencies {
 	// OAuth2 클라이언트 (소셜 로그인 등 외부 인증 제공자와의 연동)
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+	// WebClient (Reactive WebFlux)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+
 	// === API 문서화 및 유효성 검사 ===
 
 	// Swagger(OpenAPI) 문서 자동 생성

--- a/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyReflectionRepository.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyReflectionRepository.java
@@ -1,31 +1,14 @@
 package com.groomthon.habiglow.domain.daily.repository;
 
-import com.groomthon.habiglow.domain.daily.entity.DailyReflectionEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.groomthon.habiglow.domain.daily.entity.DailyReflectionEntity;
 
 public interface DailyReflectionRepository extends JpaRepository<DailyReflectionEntity, Long> {
 
-    // 주차 존재 여부: member 연관 + reflectionDate 범위
-    boolean existsByMember_IdAndReflectionDateBetween(Long memberId, LocalDate start, LocalDate end);
-
-    // available-weeks 계산용 (날짜만 가져와 Collector에서 주차 문자열로 변환)
-    @Query("select r.reflectionDate from DailyReflectionEntity r where r.member.id = :memberId")
-    List<LocalDate> findAllDatesByMemberId(@Param("memberId") Long memberId);
-
-    // 주간 매핑용
-    List<DailyReflectionEntity> findByMember_IdAndReflectionDateBetween(Long memberId, LocalDate start, LocalDate end);
-
-    // 서비스가 호출하는 이름을 그대로 맞춰줌
-    @Query("select r from DailyReflectionEntity r " +
-            "where r.member.id = :memberId and r.reflectionDate = :date")
-    Optional<DailyReflectionEntity> findByMemberIdAndReflectionDate(@Param("memberId") Long memberId,
-                                                                    @Param("date") LocalDate date);
-
+    Optional<DailyReflectionEntity> findByMemberIdAndReflectionDate(Long memberId, LocalDate date);
 
 }

--- a/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyReflectionRepository.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyReflectionRepository.java
@@ -21,7 +21,7 @@ public interface DailyReflectionRepository extends JpaRepository<DailyReflection
     // 주간 매핑용
     List<DailyReflectionEntity> findByMember_IdAndReflectionDateBetween(Long memberId, LocalDate start, LocalDate end);
 
-    // ⬇️ 서비스가 호출하는 이름을 그대로 맞춰줌
+    // 서비스가 호출하는 이름을 그대로 맞춰줌
     @Query("select r from DailyReflectionEntity r " +
             "where r.member.id = :memberId and r.reflectionDate = :date")
     Optional<DailyReflectionEntity> findByMemberIdAndReflectionDate(@Param("memberId") Long memberId,

--- a/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyReflectionRepository.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyReflectionRepository.java
@@ -1,14 +1,31 @@
 package com.groomthon.habiglow.domain.daily.repository;
 
+import com.groomthon.habiglow.domain.daily.entity.DailyReflectionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.groomthon.habiglow.domain.daily.entity.DailyReflectionEntity;
-
 public interface DailyReflectionRepository extends JpaRepository<DailyReflectionEntity, Long> {
-    
-    Optional<DailyReflectionEntity> findByMemberIdAndReflectionDate(Long memberId, LocalDate date);
+
+    // 주차 존재 여부: member 연관 + reflectionDate 범위
+    boolean existsByMember_IdAndReflectionDateBetween(Long memberId, LocalDate start, LocalDate end);
+
+    // available-weeks 계산용 (날짜만 가져와 Collector에서 주차 문자열로 변환)
+    @Query("select r.reflectionDate from DailyReflectionEntity r where r.member.id = :memberId")
+    List<LocalDate> findAllDatesByMemberId(@Param("memberId") Long memberId);
+
+    // 주간 매핑용
+    List<DailyReflectionEntity> findByMember_IdAndReflectionDateBetween(Long memberId, LocalDate start, LocalDate end);
+
+    // ⬇️ 서비스가 호출하는 이름을 그대로 맞춰줌
+    @Query("select r from DailyReflectionEntity r " +
+            "where r.member.id = :memberId and r.reflectionDate = :date")
+    Optional<DailyReflectionEntity> findByMemberIdAndReflectionDate(@Param("memberId") Long memberId,
+                                                                    @Param("date") LocalDate date);
+
 
 }

--- a/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyRoutineRepository.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyRoutineRepository.java
@@ -1,32 +1,29 @@
 package com.groomthon.habiglow.domain.daily.repository;
 
-import com.groomthon.habiglow.domain.daily.entity.DailyRoutineEntity;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
-import java.util.List;
+import com.groomthon.habiglow.domain.daily.entity.DailyRoutineEntity;
 
 public interface DailyRoutineRepository extends JpaRepository<DailyRoutineEntity, Long> {
 
-    // 주차 존재 여부: member 연관 + performedDate 범위
-    boolean existsByMember_IdAndPerformedDateBetween(Long memberId, LocalDate start, LocalDate end);
-
-    // 주간 매핑용
-    List<DailyRoutineEntity> findByMember_IdAndPerformedDateBetween(Long memberId, LocalDate start, LocalDate end);
-
-    // 서비스가 호출하는 이름을 그대로 맞춰줌 (파생쿼리 대신 JPQL)
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("delete from DailyRoutineEntity r where r.member.id = :memberId and r.performedDate = :date")
-    void deleteByMemberIdAndPerformedDate(@Param("memberId") Long memberId,
-                                          @Param("date") LocalDate date);
-
-    // 조인 페치 버전
-    @Query("select r from DailyRoutineEntity r " +
-            "join fetch r.routine " +
-            "where r.member.id = :memberId and r.performedDate = :date")
+    @Query("SELECT dr FROM DailyRoutineEntity dr " +
+            "LEFT JOIN FETCH dr.routine " +
+            "WHERE dr.member.id = :memberId AND dr.performedDate = :date")
     List<DailyRoutineEntity> findByMemberIdAndPerformedDateWithRoutine(@Param("memberId") Long memberId,
                                                                        @Param("date") LocalDate date);
+
+    Optional<DailyRoutineEntity> findByRoutineRoutineIdAndMemberIdAndPerformedDate(
+            Long routineId, Long memberId, LocalDate date);
+
+    @Modifying
+    @Query("DELETE FROM DailyRoutineEntity dr WHERE dr.member.id = :memberId AND dr.performedDate = :date")
+    void deleteByMemberIdAndPerformedDate(@Param("memberId") Long memberId, @Param("date") LocalDate date);
+
 }

--- a/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyRoutineRepository.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyRoutineRepository.java
@@ -17,7 +17,7 @@ public interface DailyRoutineRepository extends JpaRepository<DailyRoutineEntity
     // 주간 매핑용
     List<DailyRoutineEntity> findByMember_IdAndPerformedDateBetween(Long memberId, LocalDate start, LocalDate end);
 
-    // ⬇️ 서비스가 호출하는 이름을 그대로 맞춰줌 (파생쿼리 대신 JPQL)
+    // 서비스가 호출하는 이름을 그대로 맞춰줌 (파생쿼리 대신 JPQL)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from DailyRoutineEntity r where r.member.id = :memberId and r.performedDate = :date")
     void deleteByMemberIdAndPerformedDate(@Param("memberId") Long memberId,

--- a/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyRoutineRepository.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/repository/DailyRoutineRepository.java
@@ -1,29 +1,32 @@
 package com.groomthon.habiglow.domain.daily.repository;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
-
+import com.groomthon.habiglow.domain.daily.entity.DailyRoutineEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.groomthon.habiglow.domain.daily.entity.DailyRoutineEntity;
+import java.time.LocalDate;
+import java.util.List;
 
 public interface DailyRoutineRepository extends JpaRepository<DailyRoutineEntity, Long> {
-    
-    @Query("SELECT dr FROM DailyRoutineEntity dr " +
-           "LEFT JOIN FETCH dr.routine " +
-           "WHERE dr.member.id = :memberId AND dr.performedDate = :date")
-    List<DailyRoutineEntity> findByMemberIdAndPerformedDateWithRoutine(@Param("memberId") Long memberId, 
-                                                                       @Param("date") LocalDate date);
-    
-    Optional<DailyRoutineEntity> findByRoutineRoutineIdAndMemberIdAndPerformedDate(
-        Long routineId, Long memberId, LocalDate date);
-    
-    @Modifying
-    @Query("DELETE FROM DailyRoutineEntity dr WHERE dr.member.id = :memberId AND dr.performedDate = :date")
-    void deleteByMemberIdAndPerformedDate(@Param("memberId") Long memberId, @Param("date") LocalDate date);
 
+    // 주차 존재 여부: member 연관 + performedDate 범위
+    boolean existsByMember_IdAndPerformedDateBetween(Long memberId, LocalDate start, LocalDate end);
+
+    // 주간 매핑용
+    List<DailyRoutineEntity> findByMember_IdAndPerformedDateBetween(Long memberId, LocalDate start, LocalDate end);
+
+    // ⬇️ 서비스가 호출하는 이름을 그대로 맞춰줌 (파생쿼리 대신 JPQL)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from DailyRoutineEntity r where r.member.id = :memberId and r.performedDate = :date")
+    void deleteByMemberIdAndPerformedDate(@Param("memberId") Long memberId,
+                                          @Param("date") LocalDate date);
+
+    // 조인 페치 버전
+    @Query("select r from DailyRoutineEntity r " +
+            "join fetch r.routine " +
+            "where r.member.id = :memberId and r.performedDate = :date")
+    List<DailyRoutineEntity> findByMemberIdAndPerformedDateWithRoutine(@Param("memberId") Long memberId,
+                                                                       @Param("date") LocalDate date);
 }

--- a/src/main/java/com/groomthon/habiglow/domain/daily/service/DailyReflectionService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/service/DailyReflectionService.java
@@ -20,29 +20,29 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional
 public class DailyReflectionService {
-    
+
     private final DailyReflectionRepository reflectionRepository;
     private final MemberRepository memberRepository;
-    
-    public DailyReflectionEntity saveReflection(Long memberId, LocalDate date, 
-                                               String content, EmotionType emotion) {
-        
+
+    public DailyReflectionEntity saveReflection(Long memberId, LocalDate date,
+                                                String content, EmotionType emotion) {
+
         MemberEntity member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
-        
+                .orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
+
         Optional<DailyReflectionEntity> existing = reflectionRepository
-            .findByMemberIdAndReflectionDate(memberId, date);
-        
+                .findByMemberIdAndReflectionDate(memberId, date);
+
         if (existing.isPresent()) {
             DailyReflectionEntity entity = existing.get();
             entity.updateReflection(content, emotion);
             return entity;
         }
-        
+
         DailyReflectionEntity entity = DailyReflectionEntity.create(member, content, emotion, date);
         return reflectionRepository.save(entity);
     }
-    
+
     @Transactional(readOnly = true)
     public Optional<DailyReflectionEntity> getReflection(Long memberId, LocalDate date) {
         return reflectionRepository.findByMemberIdAndReflectionDate(memberId, date);

--- a/src/main/java/com/groomthon/habiglow/domain/daily/service/DailyRoutineService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/daily/service/DailyRoutineService.java
@@ -17,35 +17,35 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional
 public class DailyRoutineService {
-    
+
     private final DailyRoutineRepository dailyRoutineRepository;
     private final ConsecutiveDaysCalculator consecutiveDaysCalculator;
-    
-    public List<DailyRoutineEntity> saveRoutineRecords(Long memberId, LocalDate date, 
-                                                      List<RoutinePerformanceRequest> records) {
-        
+
+    public List<DailyRoutineEntity> saveRoutineRecords(Long memberId, LocalDate date,
+                                                       List<RoutinePerformanceRequest> records) {
+
         dailyRoutineRepository.deleteByMemberIdAndPerformedDate(memberId, date);
-        
+
         List<DailyRoutineEntity> entities = new ArrayList<>();
-        
+
         for (RoutinePerformanceRequest record : records) {
             int consecutiveDays = consecutiveDaysCalculator.calculate(
-                record.getRoutineId(), memberId, date, record.getPerformanceLevel());
-            
+                    record.getRoutineId(), memberId, date, record.getPerformanceLevel());
+
             DailyRoutineEntity entity = DailyRoutineEntity.create(
-                record.getRoutine(),
-                record.getMember(),
-                record.getPerformanceLevel(),
-                date,
-                consecutiveDays
+                    record.getRoutine(),
+                    record.getMember(),
+                    record.getPerformanceLevel(),
+                    date,
+                    consecutiveDays
             );
-            
+
             entities.add(entity);
         }
-        
+
         return dailyRoutineRepository.saveAll(entities);
     }
-    
+
     @Transactional(readOnly = true)
     public List<DailyRoutineEntity> getTodayRoutines(Long memberId, LocalDate date) {
         return dailyRoutineRepository.findByMemberIdAndPerformedDateWithRoutine(memberId, date);

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/config/OpenAiProperties.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/config/OpenAiProperties.java
@@ -1,0 +1,31 @@
+package com.groomthon.habiglow.domain.dashboard.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * OpenAI API 설정 Properties
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openai.api")
+public class OpenAiProperties {
+
+    private String key;
+    private String baseUrl = "https://api.openai.com/v1";
+    private String model = "gpt-4o-mini";
+    private String timeout = "30s";
+    private int maxRetries = 3;
+
+    public long getTimeoutMillis() {
+        // "30s" -> 30000ms 변환
+        if (timeout.endsWith("s")) {
+            return Long.parseLong(timeout.substring(0, timeout.length() - 1)) * 1000;
+        }
+        return 30000; // 기본값
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/DashboardController.java
@@ -1,0 +1,130 @@
+package com.groomthon.habiglow.domain.dashboard.controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.groomthon.habiglow.domain.dashboard.dto.response.WeeklyInsightResponse;
+import com.groomthon.habiglow.domain.dashboard.service.WeeklyInsightService;
+import com.groomthon.habiglow.global.jwt.JwtMemberExtractor;
+import com.groomthon.habiglow.global.response.ApiSuccessCode;
+import com.groomthon.habiglow.global.response.AutoApiResponse;
+import com.groomthon.habiglow.global.response.SuccessCode;
+import com.groomthon.habiglow.global.swagger.CustomExceptionDescription;
+import com.groomthon.habiglow.global.swagger.SwaggerResponseDescription;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * HabiGlow AI 대시보드 컨트롤러
+ *
+ * 주간 습관 분석, 감정 변화 패턴 분석,
+ * 성공/실패 패턴에 대한 공감과 응원 메시지 제공
+ */
+@RestController
+@RequestMapping("/api/dashboard")
+@RequiredArgsConstructor
+@AutoApiResponse
+@Tag(name = "AI 대시보드 API", description = "HabiGlow AI 기반 주간 습관 분석 및 인사이트 제공")
+public class DashboardController {
+
+    private final WeeklyInsightService weeklyInsightService;
+    private final JwtMemberExtractor jwtMemberExtractor;
+
+    @Operation(
+            summary = "지난주 AI 분석 생성",
+            description = "지난주 월~일 데이터를 기반으로 습관 패턴과 감정 변화를 분석하여 공감과 응원 메시지를 제공합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "AI 분석 성공"),
+            @ApiResponse(responseCode = "400", description = "분석할 데이터 부족"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "AI 분석 처리 실패")
+    })
+    @PostMapping("/insight/weekly/last")
+    @PreAuthorize("isAuthenticated()")
+    @CustomExceptionDescription(SwaggerResponseDescription.AI_ANALYSIS_ERROR)
+    @SuccessCode(ApiSuccessCode.AI_INSIGHT_SUCCESS)
+    public WeeklyInsightResponse generateLastWeekInsight(HttpServletRequest request) {
+        Long memberId = jwtMemberExtractor.extractMemberId(request);
+        return weeklyInsightService.generateLastWeekInsight(memberId);
+    }
+
+    @Operation(
+            summary = "특정 주차 AI 분석 생성",
+            description = "지정한 주차(월요일 시작)의 데이터를 기반으로 AI 분석을 수행합니다. 과거 주차만 분석 가능합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "AI 분석 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 주차 또는 분석할 데이터 부족"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @PostMapping("/insight/weekly/specific")
+    @PreAuthorize("isAuthenticated()")
+    @CustomExceptionDescription(SwaggerResponseDescription.AI_ANALYSIS_ERROR)
+    @SuccessCode(ApiSuccessCode.AI_INSIGHT_SUCCESS)
+    public WeeklyInsightResponse generateWeekInsight(
+            HttpServletRequest request,
+            @Parameter(description = "분석할 주차의 월요일 날짜", example = "2025-08-25")
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate weekStart) {
+
+        Long memberId = jwtMemberExtractor.extractMemberId(request);
+        return weeklyInsightService.generateWeekInsight(memberId, weekStart);
+    }
+
+    @Operation(
+            summary = "이번주 진행상황 AI 분석",
+            description = "이번주 현재까지의 데이터를 기반으로 진행상황을 분석합니다. (참고용)"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "AI 분석 성공"),
+            @ApiResponse(responseCode = "400", description = "분석할 데이터 부족"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @PostMapping("/insight/weekly/current")
+    @PreAuthorize("isAuthenticated()")
+    @CustomExceptionDescription(SwaggerResponseDescription.AI_ANALYSIS_ERROR)
+    @SuccessCode(ApiSuccessCode.AI_INSIGHT_SUCCESS)
+    public WeeklyInsightResponse generateThisWeekInsight(HttpServletRequest request) {
+        Long memberId = jwtMemberExtractor.extractMemberId(request);
+        return weeklyInsightService.generateThisWeekInsight(memberId);
+    }
+
+    @Operation(
+            summary = "분석 가능한 주차 목록 조회",
+            description = "AI 분석이 가능한 최근 4주간의 주차 목록을 반환합니다. (월요일 날짜 기준)"
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/insight/available-weeks")
+    @PreAuthorize("isAuthenticated()")
+    @SuccessCode(ApiSuccessCode.SUCCESS)
+    public List<LocalDate> getAvailableWeeks(HttpServletRequest request) {
+        Long memberId = jwtMemberExtractor.extractMemberId(request);
+        return weeklyInsightService.getAvailableWeeks(memberId);
+    }
+
+    @Operation(
+            summary = "지난주 완료 여부 확인",
+            description = "현재 시점에서 지난주가 완료되어 분석 가능한지 확인합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "확인 성공")
+    @GetMapping("/insight/last-week-completed")
+    @PreAuthorize("isAuthenticated()")
+    @SuccessCode(ApiSuccessCode.SUCCESS)
+    public boolean isLastWeekCompleted() {
+        return weeklyInsightService.isLastWeekCompleted();
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/DashboardController.java
@@ -38,7 +38,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/dashboard")
 @RequiredArgsConstructor
 @AutoApiResponse
-@Tag(name = "AI 대시보드 API", description = "HabiGlow AI 기반 주간 습관 분석 및 인사이트 제공")
+@Tag(name = "대시보드 API", description = "HabiGlow AI 기반 주간 습관 분석 및 인사이트 제공과 주간 통계")
 public class DashboardController {
 
     private final WeeklyInsightService weeklyInsightService;

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/controller/DashboardController.java
@@ -1,130 +1,72 @@
 package com.groomthon.habiglow.domain.dashboard.controller;
 
-import java.time.LocalDate;
-import java.util.List;
-
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.groomthon.habiglow.domain.dashboard.dto.response.WeeklyInsightResponse;
 import com.groomthon.habiglow.domain.dashboard.service.WeeklyInsightService;
 import com.groomthon.habiglow.global.jwt.JwtMemberExtractor;
-import com.groomthon.habiglow.global.response.ApiSuccessCode;
-import com.groomthon.habiglow.global.response.AutoApiResponse;
-import com.groomthon.habiglow.global.response.SuccessCode;
-import com.groomthon.habiglow.global.swagger.CustomExceptionDescription;
-import com.groomthon.habiglow.global.swagger.SwaggerResponseDescription;
-
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
-/**
- * HabiGlow AI 대시보드 컨트롤러
- *
- * 주간 습관 분석, 감정 변화 패턴 분석,
- * 성공/실패 패턴에 대한 공감과 응원 메시지 제공
- */
+import java.time.LocalDate;
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/dashboard")
 @RequiredArgsConstructor
-@AutoApiResponse
-@Tag(name = "대시보드 API", description = "HabiGlow AI 기반 주간 습관 분석 및 인사이트 제공과 주간 통계")
 public class DashboardController {
 
     private final WeeklyInsightService weeklyInsightService;
     private final JwtMemberExtractor jwtMemberExtractor;
 
-    @Operation(
-            summary = "지난주 AI 분석 생성",
-            description = "지난주 월~일 데이터를 기반으로 습관 패턴과 감정 변화를 분석하여 공감과 응원 메시지를 제공합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "AI 분석 성공"),
-            @ApiResponse(responseCode = "400", description = "분석할 데이터 부족"),
-            @ApiResponse(responseCode = "401", description = "인증 실패"),
-            @ApiResponse(responseCode = "500", description = "AI 분석 처리 실패")
-    })
+    @Operation(summary = "지난주 AI 분석 생성")
+    @ApiResponse(responseCode = "200", description = "성공")
     @PostMapping("/insight/weekly/last")
     @PreAuthorize("isAuthenticated()")
-    @CustomExceptionDescription(SwaggerResponseDescription.AI_ANALYSIS_ERROR)
-    @SuccessCode(ApiSuccessCode.AI_INSIGHT_SUCCESS)
     public WeeklyInsightResponse generateLastWeekInsight(HttpServletRequest request) {
         Long memberId = jwtMemberExtractor.extractMemberId(request);
         return weeklyInsightService.generateLastWeekInsight(memberId);
     }
 
-    @Operation(
-            summary = "특정 주차 AI 분석 생성",
-            description = "지정한 주차(월요일 시작)의 데이터를 기반으로 AI 분석을 수행합니다. 과거 주차만 분석 가능합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "AI 분석 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 주차 또는 분석할 데이터 부족"),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
-    })
+    @Operation(summary = "특정 주차 AI 분석 생성", description = "weekStart는 해당 주차의 월요일(yyyy-MM-dd)")
+    @ApiResponse(responseCode = "200", description = "성공")
     @PostMapping("/insight/weekly/specific")
     @PreAuthorize("isAuthenticated()")
-    @CustomExceptionDescription(SwaggerResponseDescription.AI_ANALYSIS_ERROR)
-    @SuccessCode(ApiSuccessCode.AI_INSIGHT_SUCCESS)
-    public WeeklyInsightResponse generateWeekInsight(
+    public WeeklyInsightResponse generateSpecificWeekInsight(
             HttpServletRequest request,
-            @Parameter(description = "분석할 주차의 월요일 날짜", example = "2025-08-25")
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate weekStart) {
-
+            @RequestParam("weekStart") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart
+    ) {
         Long memberId = jwtMemberExtractor.extractMemberId(request);
-        return weeklyInsightService.generateWeekInsight(memberId, weekStart);
+        return weeklyInsightService.generateSpecificWeekInsight(memberId, weekStart);
     }
 
-    @Operation(
-            summary = "이번주 진행상황 AI 분석",
-            description = "이번주 현재까지의 데이터를 기반으로 진행상황을 분석합니다. (참고용)"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "AI 분석 성공"),
-            @ApiResponse(responseCode = "400", description = "분석할 데이터 부족"),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
-    })
+    @Operation(summary = "이번주 진행상황 AI 분석")
+    @ApiResponse(responseCode = "200", description = "성공")
     @PostMapping("/insight/weekly/current")
     @PreAuthorize("isAuthenticated()")
-    @CustomExceptionDescription(SwaggerResponseDescription.AI_ANALYSIS_ERROR)
-    @SuccessCode(ApiSuccessCode.AI_INSIGHT_SUCCESS)
     public WeeklyInsightResponse generateThisWeekInsight(HttpServletRequest request) {
         Long memberId = jwtMemberExtractor.extractMemberId(request);
         return weeklyInsightService.generateThisWeekInsight(memberId);
     }
 
-    @Operation(
-            summary = "분석 가능한 주차 목록 조회",
-            description = "AI 분석이 가능한 최근 4주간의 주차 목록을 반환합니다. (월요일 날짜 기준)"
-    )
-    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @Operation(summary = "분석 가능한 주차 목록 조회")
+    @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/insight/available-weeks")
     @PreAuthorize("isAuthenticated()")
-    @SuccessCode(ApiSuccessCode.SUCCESS)
-    public List<LocalDate> getAvailableWeeks(HttpServletRequest request) {
+    public List<String> getAvailableWeeks(HttpServletRequest request) {
         Long memberId = jwtMemberExtractor.extractMemberId(request);
         return weeklyInsightService.getAvailableWeeks(memberId);
     }
 
-    @Operation(
-            summary = "지난주 완료 여부 확인",
-            description = "현재 시점에서 지난주가 완료되어 분석 가능한지 확인합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "확인 성공")
+    @Operation(summary = "지난주 완료 여부 확인")
+    @ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/insight/last-week-completed")
     @PreAuthorize("isAuthenticated()")
-    @SuccessCode(ApiSuccessCode.SUCCESS)
-    public boolean isLastWeekCompleted() {
-        return weeklyInsightService.isLastWeekCompleted();
+    public boolean isLastWeekCompleted(HttpServletRequest request) {
+        Long memberId = jwtMemberExtractor.extractMemberId(request);
+        return weeklyInsightService.isLastWeekCompleted(memberId);
     }
 }

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/dto/WeeklyAnalysisData.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/dto/WeeklyAnalysisData.java
@@ -1,0 +1,68 @@
+package com.groomthon.habiglow.domain.dashboard.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * AI 분석을 위한 주간 데이터 구조체
+ * 기획서의 JSON 포맷을 그대로 따라 구현
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "AI 분석을 위한 주간 데이터")
+public class WeeklyAnalysisData {
+
+    @JsonProperty("week_start")
+    @Schema(description = "주간 시작일 (월요일)", example = "2025-08-25")
+    private String weekStart;
+
+    @JsonProperty("week_end")
+    @Schema(description = "주간 종료일 (일요일)", example = "2025-08-31")
+    private String weekEnd;
+
+    @Schema(description = "7일간의 일별 데이터")
+    private List<DayData> days;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "하루 데이터")
+    public static class DayData {
+
+        @Schema(description = "날짜", example = "2025-08-25")
+        private String date;
+
+        @Schema(description = "감정 이모지", example = "🙂")
+        private String emotion;
+
+        @Schema(description = "루틴 수행 결과 목록")
+        private List<RoutineResult> routines;
+
+        @Schema(description = "하루 회고 메모", example = "회의가 길어 영어 학습을 못 함")
+        private String note;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "루틴 수행 결과")
+    public static class RoutineResult {
+
+        @Schema(description = "루틴 이름", example = "물 마시기")
+        private String name;
+
+        @Schema(description = "수행 결과", example = "SUCCESS", allowableValues = {"SUCCESS", "PARTIAL", "FAIL"})
+        private String result;
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/dto/response/WeeklyInsightResponse.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/dto/response/WeeklyInsightResponse.java
@@ -1,0 +1,57 @@
+package com.groomthon.habiglow.domain.dashboard.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * AI 주간 분석 응답 DTO
+ * 기획서의 JSON 스키마를 그대로 구현
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "HabiGlow AI 주간 분석 결과")
+public class WeeklyInsightResponse {
+
+    @JsonProperty("week_range")
+    @Schema(description = "분석 기간", example = "2025-08-25 ~ 2025-08-31")
+    private String weekRange;
+
+    @JsonProperty("mood_daily")
+    @Schema(description = "7일간 일별 감정 이모지", example = "[\"🙂\",\"🙂\",\"😐\",\"🙂\",\"😀\",\"🙂\",\"🙂\"]")
+    private List<String> moodDaily;
+
+    @JsonProperty("mood_trend")
+    @Schema(description = "감정 변화 추세", example = "안정", allowableValues = {"상승", "하락", "안정"})
+    private String moodTrend;
+
+    @JsonProperty("weekly_summary")
+    @Schema(description = "주간 요약 (80자 이내)", example = "이번 주 기록은 안정적이에요. 수분과 스트레칭의 꾸준함이 돋보여요.")
+    private String weeklySummary;
+
+    @JsonProperty("good_points")
+    @Schema(description = "잘한 점 목록 (1~3개, 각 60자 이내)",
+            example = "[\"물 마시기 6일 지속\", \"스트레칭 5회 유지\"]")
+    private List<String> goodPoints;
+
+    @JsonProperty("failure_patterns")
+    @Schema(description = "실패 패턴 목록 (0~3개, 각 60자 이내)",
+            example = "[\"회의 있는 날 영어 누락 반복\"]")
+    private List<String> failurePatterns;
+
+    @Schema(description = "공감 메시지 (80자 이내)",
+            example = "바쁜 일정 속에서도 기본 루틴을 지키신 점이 인상적이에요.")
+    private String empathy;
+
+    @Schema(description = "응원 메시지 (80자 이내)",
+            example = "회의 날엔 영어를 10분 미니 세션으로 가볍게 이어가보세요!")
+    private String encouragement;
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/OpenAiClient.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/OpenAiClient.java
@@ -1,0 +1,174 @@
+package com.groomthon.habiglow.domain.dashboard.service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.groomthon.habiglow.domain.dashboard.config.OpenAiProperties;
+import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData;
+import com.groomthon.habiglow.domain.dashboard.dto.response.WeeklyInsightResponse;
+import com.groomthon.habiglow.global.exception.BaseException;
+import com.groomthon.habiglow.global.response.ErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * OpenAI Chat Completions API 클라이언트
+ * 기획서의 프롬프트와 JSON 스키마를 적용하여 주간 분석 수행
+ */
+@Slf4j
+@Service
+public class OpenAiClient {
+
+    private final WebClient webClient;
+    private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper;
+
+    // 기획서에서 정의한 시스템 프롬프트
+    private static final String SYSTEM_PROMPT = """
+        You are HabiGlow Weekly Analyst.
+        
+        Purpose
+        - Summarize Mon–Sun habit successes/failures and mood changes.
+        - Provide exactly ONE empathy sentence and ONE encouragement sentence.
+        - No blame; describe failures as patterns.
+        
+        Style (Korean, 존댓말)
+        - Always write in Korean (formal, 존댓말).
+        - Be concise and concrete (numbers, counts).
+        - Use emojis only in mood fields; other texts: 0–1 emoji at most.
+        
+        Output rules
+        - Must follow the provided JSON schema exactly (no extra fields).
+        - Length guide: weekly_summary ≤ 80 chars, empathy ≤ 80 chars, encouragement ≤ 80 chars.
+        """;
+
+    public OpenAiClient(OpenAiProperties properties) {
+        this.properties = properties;
+        this.objectMapper = new ObjectMapper();
+        this.webClient = WebClient.builder()
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getKey())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024 * 1024)) // 1MB
+                .build();
+
+        log.info("OpenAI 클라이언트 초기화 완료 - Model: {}, BaseURL: {}",
+                properties.getModel(), properties.getBaseUrl());
+    }
+
+    /**
+     * 주간 데이터를 분석하여 인사이트 생성
+     */
+    public WeeklyInsightResponse generateWeeklyInsight(WeeklyAnalysisData weeklyData) {
+        try {
+            String userMessage = String.format("Here is the weekly data in JSON:\n\n%s\n\nFollow the schema strictly.",
+                    objectMapper.writeValueAsString(weeklyData));
+
+            Map<String, Object> requestBody = buildChatCompletionRequest(userMessage);
+
+            log.info("OpenAI API 호출 시작 - 주간 분석 ({})", weeklyData.getWeekStart());
+
+            String response = webClient.post()
+                    .uri("/chat/completions")
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .timeout(Duration.ofMillis(properties.getTimeoutMillis()))
+                    .block();
+
+            return parseResponse(response);
+
+        } catch (WebClientResponseException e) {
+            log.error("OpenAI API 호출 실패 - Status: {}, Body: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new BaseException(ErrorCode.AI_ANALYSIS_FAILED);
+        } catch (Exception e) {
+            log.error("AI 분석 중 예외 발생", e);
+            throw new BaseException(ErrorCode.AI_ANALYSIS_FAILED);
+        }
+    }
+
+    private Map<String, Object> buildChatCompletionRequest(String userMessage) {
+        // JSON Schema 정의 (기획서 스키마)
+        Map<String, Object> schema = Map.of(
+                "type", "object",
+                "properties", Map.of(
+                        "week_range", Map.of("type", "string", "description", "YYYY-MM-DD ~ YYYY-MM-DD"),
+                        "mood_daily", Map.of(
+                                "type", "array",
+                                "items", Map.of("type", "string", "enum", List.of("😀","🙂","😐","☁️","😞")),
+                                "minItems", 7,
+                                "maxItems", 7
+                        ),
+                        "mood_trend", Map.of("type", "string", "enum", List.of("상승","하락","안정")),
+                        "weekly_summary", Map.of("type", "string", "maxLength", 80),
+                        "good_points", Map.of(
+                                "type", "array",
+                                "items", Map.of("type", "string", "maxLength", 60),
+                                "minItems", 1,
+                                "maxItems", 3
+                        ),
+                        "failure_patterns", Map.of(
+                                "type", "array",
+                                "items", Map.of("type", "string", "maxLength", 60),
+                                "minItems", 0,
+                                "maxItems", 3
+                        ),
+                        "empathy", Map.of("type", "string", "maxLength", 80),
+                        "encouragement", Map.of("type", "string", "maxLength", 80)
+                ),
+                "required", List.of(
+                        "week_range", "mood_daily", "mood_trend", "weekly_summary",
+                        "good_points", "empathy", "encouragement"
+                ),
+                "additionalProperties", false
+        );
+
+        return Map.of(
+                "model", properties.getModel(),
+                "temperature", 0.2,
+                "messages", List.of(
+                        Map.of("role", "system", "content", SYSTEM_PROMPT),
+                        Map.of("role", "user", "content", userMessage)
+                ),
+                "response_format", Map.of(
+                        "type", "json_schema",
+                        "json_schema", Map.of(
+                                "name", "HabiGlowWeeklyReport",
+                                "strict", true,
+                                "schema", schema
+                        )
+                )
+        );
+    }
+
+    private WeeklyInsightResponse parseResponse(String response) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode choices = root.path("choices");
+
+            if (choices.isEmpty()) {
+                throw new RuntimeException("OpenAI 응답에 choices가 없습니다");
+            }
+
+            String content = choices.get(0).path("message").path("content").asText();
+
+            log.info("AI 분석 완료 - 응답 길이: {} chars", content.length());
+            log.debug("AI 응답 내용: {}", content);
+
+            return objectMapper.readValue(content, WeeklyInsightResponse.class);
+
+        } catch (Exception e) {
+            log.error("OpenAI 응답 파싱 실패", e);
+            throw new BaseException(ErrorCode.AI_RESPONSE_PARSE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/OpenAiClient.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/OpenAiClient.java
@@ -128,7 +128,7 @@ public class OpenAiClient {
                 ),
                 "required", List.of(
                         "week_range", "mood_daily", "mood_trend", "weekly_summary",
-                        "good_points", "empathy", "encouragement"
+                        "good_points","failure_patterns", "empathy", "encouragement"
                 ),
                 "additionalProperties", false
         );

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDataCollector.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDataCollector.java
@@ -1,0 +1,187 @@
+package com.groomthon.habiglow.domain.dashboard.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomthon.habiglow.domain.daily.entity.DailyReflectionEntity;
+import com.groomthon.habiglow.domain.daily.entity.DailyRoutineEntity;
+import com.groomthon.habiglow.domain.daily.entity.EmotionType;
+import com.groomthon.habiglow.domain.daily.entity.PerformanceLevel;
+import com.groomthon.habiglow.domain.daily.repository.DailyReflectionRepository;
+import com.groomthon.habiglow.domain.daily.repository.DailyRoutineRepository;
+import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData;
+import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData.DayData;
+import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData.RoutineResult;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 주간 AI 분석을 위한 데이터 수집 서비스
+ * 월~일 7일 주기로 회고 및 루틴 데이터를 수집하여 AI 분석용 JSON 포맷으로 변환
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WeeklyDataCollector {
+
+    private final DailyReflectionRepository reflectionRepository;
+    private final DailyRoutineRepository routineRepository;
+
+    /**
+     * 특정 주의 데이터를 수집 (월-일)
+     */
+    public WeeklyAnalysisData collectWeeklyData(Long memberId, LocalDate weekStart) {
+        validateWeekStart(weekStart);
+
+        LocalDate weekEnd = weekStart.plusDays(6);
+        List<DayData> days = new ArrayList<>();
+
+        log.info("주간 데이터 수집 시작: {} ~ {} (회원ID: {})", weekStart, weekEnd, memberId);
+
+        for (int dayOffset = 0; dayOffset < 7; dayOffset++) {
+            LocalDate currentDate = weekStart.plusDays(dayOffset);
+            DayData dayData = collectDayData(memberId, currentDate);
+            days.add(dayData);
+        }
+
+        log.info("주간 데이터 수집 완료: 총 {}일 데이터", days.size());
+
+        return WeeklyAnalysisData.builder()
+                .weekStart(weekStart.toString())
+                .weekEnd(weekEnd.toString())
+                .days(days)
+                .build();
+    }
+
+    /**
+     * 지난주 데이터를 수집 (이번주 월요일 기준 지난주 월~일)
+     */
+    public WeeklyAnalysisData collectLastWeekData(Long memberId) {
+        LocalDate thisMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate lastWeekMonday = thisMonday.minusWeeks(1);
+
+        return collectWeeklyData(memberId, lastWeekMonday);
+    }
+
+    /**
+     * 이번주 데이터를 수집 (월~현재까지)
+     */
+    public WeeklyAnalysisData collectThisWeekData(Long memberId) {
+        LocalDate thisMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        return collectWeeklyData(memberId, thisMonday);
+    }
+
+    private DayData collectDayData(Long memberId, LocalDate date) {
+        // 하루 회고 데이터
+        DailyReflectionEntity reflection = reflectionRepository
+                .findByMemberIdAndReflectionDate(memberId, date)
+                .orElse(null);
+
+        // 하루 루틴 기록들
+        List<DailyRoutineEntity> routineRecords = routineRepository
+                .findByMemberIdAndPerformedDateWithRoutine(memberId, date);
+
+        String emotion = mapEmotionToEmoji(reflection != null ? reflection.getEmotion() : EmotionType.SOSO);
+        String note = reflection != null ? reflection.getReflectionContent() : "기록 없음";
+
+        List<RoutineResult> routines = routineRecords.stream()
+                .map(this::mapRoutineToResult)
+                .collect(Collectors.toList());
+
+        return DayData.builder()
+                .date(date.toString())
+                .emotion(emotion)
+                .routines(routines)
+                .note(note)
+                .build();
+    }
+
+    private RoutineResult mapRoutineToResult(DailyRoutineEntity routineRecord) {
+        String result = mapPerformanceToResult(routineRecord.getPerformanceLevel());
+        String routineName = routineRecord.getRoutineTitle();
+
+        return RoutineResult.builder()
+                .name(routineName)
+                .result(result)
+                .build();
+    }
+
+    /**
+     * 감정 타입을 이모지로 변환
+     */
+    private String mapEmotionToEmoji(EmotionType emotionType) {
+        return switch (emotionType) {
+            case HAPPY -> "😀";
+            case SOSO -> "🙂";
+            case SAD -> "😐";
+            case MAD -> "☁️";
+        };
+    }
+
+    /**
+     * 성과 레벨을 결과로 변환
+     */
+    private String mapPerformanceToResult(PerformanceLevel performanceLevel) {
+        return switch (performanceLevel) {
+            case FULL_SUCCESS -> "SUCCESS";
+            case PARTIAL_SUCCESS -> "PARTIAL";
+            case NOT_PERFORMED -> "FAIL";
+        };
+    }
+
+    private void validateWeekStart(LocalDate weekStart) {
+        if (weekStart.getDayOfWeek() != DayOfWeek.MONDAY) {
+            throw new IllegalArgumentException("주간 데이터는 월요일부터 시작해야 합니다. 입력된 날짜: " + weekStart);
+        }
+    }
+
+    /**
+     * 회원의 분석 가능한 주차 목록 조회 (최근 4주)
+     */
+    public List<LocalDate> getAvailableWeeks(Long memberId) {
+        LocalDate currentMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        List<LocalDate> weeks = new ArrayList<>();
+
+        // 최근 4주치 월요일 날짜 생성
+        for (int i = 0; i < 4; i++) {
+            LocalDate weekStart = currentMonday.minusWeeks(i);
+
+            // 해당 주에 데이터가 있는지 간단 체크
+            boolean hasData = hasWeeklyData(memberId, weekStart);
+            if (hasData) {
+                weeks.add(weekStart);
+            }
+        }
+
+        return weeks;
+    }
+
+    private boolean hasWeeklyData(Long memberId, LocalDate weekStart) {
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        // 해당 주차에 회고나 루틴 기록이 하나라도 있는지 확인
+        long reflectionCount = reflectionRepository.findAll().stream()
+                .filter(r -> r.getMember().getId().equals(memberId))
+                .filter(r -> !r.getReflectionDate().isBefore(weekStart))
+                .filter(r -> !r.getReflectionDate().isAfter(weekEnd))
+                .count();
+
+        long routineCount = routineRepository.findAll().stream()
+                .filter(r -> r.getMember().getId().equals(memberId))
+                .filter(r -> !r.getPerformedDate().isBefore(weekStart))
+                .filter(r -> !r.getPerformedDate().isAfter(weekEnd))
+                .count();
+
+        return reflectionCount > 0 || routineCount > 0;
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDataCollector.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDataCollector.java
@@ -52,7 +52,7 @@ public class WeeklyDataCollector {
     private boolean hasWeekData(Long memberId, LocalDate weekStart) {
         LocalDate weekEnd = weekStart.plusDays(6);
         boolean hasReflections =
-                reflectionRepository.existsByMember_IdAndReflectionDateBetween(memberId, weekStart, weekEnd); // ✅ 여기!
+                reflectionRepository.existsByMember_IdAndReflectionDateBetween(memberId, weekStart, weekEnd);
         boolean hasRoutines =
                 dailyRoutineRepository.existsByMember_IdAndPerformedDateBetween(memberId, weekStart, weekEnd);
         return hasReflections || hasRoutines;

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDataCollector.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyDataCollector.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.groomthon.habiglow.domain.dashboard.util.WeeklyDummyDataGenerator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,12 +67,20 @@ public class WeeklyDataCollector {
     /**
      * 지난주 데이터를 수집 (이번주 월요일 기준 지난주 월~일)
      */
+    /**
+     * 지난주 데이터를 수집 (이번주 월요일 기준 지난주 월~일)
+     */
     public WeeklyAnalysisData collectLastWeekData(Long memberId) {
         LocalDate thisMonday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         LocalDate lastWeekMonday = thisMonday.minusWeeks(1);
 
-        return collectWeeklyData(memberId, lastWeekMonday);
+        // ✅ 실제 DB 대신 더미 데이터 반환 (Swagger 테스트용)
+        return WeeklyDummyDataGenerator.generate(memberId, lastWeekMonday);
+
+        // 🔽 실제 DB 쓰려면 기존 코드 사용
+        // return collectWeeklyData(memberId, lastWeekMonday);
     }
+
 
     /**
      * 이번주 데이터를 수집 (월~현재까지)

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyInsightService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyInsightService.java
@@ -2,24 +2,20 @@ package com.groomthon.habiglow.domain.dashboard.service;
 
 import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData;
 import com.groomthon.habiglow.domain.dashboard.dto.response.WeeklyInsightResponse;
-import com.groomthon.habiglow.domain.dashboard.service.WeeklyDataCollector;
-import com.groomthon.habiglow.domain.dashboard.service.OpenAiClient;
-
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WeeklyInsightService {
 
     private final WeeklyDataCollector dataCollector;
-    private final OpenAiClient openAiClient;
+    private final OpenAiClient openAiClient; // 패키지 경로는 프로젝트에 맞게
 
     public WeeklyInsightResponse generateLastWeekInsight(Long memberId) {
         WeeklyAnalysisData data = dataCollector.collectLastWeekData(memberId);
@@ -43,8 +39,13 @@ public class WeeklyInsightService {
         return dataCollector.isLastWeekCompleted(memberId);
     }
 
-    public java.util.List<String> getAvailableWeeks(Long memberId) {
+    public List<String> getAvailableWeeks(Long memberId) {
         return dataCollector.getAvailableWeeks(memberId);
+    }
+
+    /** 컨트롤러에서 주차 실데이터 존재 여부 체크용 */
+    public boolean hasRealWeekData(Long memberId, LocalDate weekStart) {
+        return dataCollector.hasRealWeekData(memberId, weekStart);
     }
 
     private void validateSkeleton(WeeklyAnalysisData weekly) {

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyInsightService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyInsightService.java
@@ -1,27 +1,17 @@
 package com.groomthon.habiglow.domain.dashboard.service;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData;
 import com.groomthon.habiglow.domain.dashboard.dto.response.WeeklyInsightResponse;
-import com.groomthon.habiglow.global.exception.BaseException;
-import com.groomthon.habiglow.global.response.ErrorCode;
+import com.groomthon.habiglow.domain.dashboard.service.WeeklyDataCollector;
+import com.groomthon.habiglow.domain.dashboard.service.OpenAiClient;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-/**
- * HabiGlow AI 주간 분석 서비스
- *
- * 월~일 7일 주기로 사용자의 습관 데이터를 분석하여
- * 감정 변화 패턴과 루틴 성공/실패에 대한 공감과 응원 메시지 생성
- */
+import java.time.LocalDate;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -31,113 +21,35 @@ public class WeeklyInsightService {
     private final WeeklyDataCollector dataCollector;
     private final OpenAiClient openAiClient;
 
-    /**
-     * 지난주 데이터 기반 AI 분석 생성
-     * (이번주 월요일 기준 지난주 월~일)
-     */
     public WeeklyInsightResponse generateLastWeekInsight(Long memberId) {
-        log.info("지난주 AI 분석 요청 - 회원ID: {}", memberId);
-
-        WeeklyAnalysisData weeklyData = dataCollector.collectLastWeekData(memberId);
-
-        validateWeeklyData(weeklyData);
-
-        WeeklyInsightResponse insight = openAiClient.generateWeeklyInsight(weeklyData);
-
-        log.info("지난주 AI 분석 완료 - 회원ID: {}, 분석 기간: {}",
-                memberId, insight.getWeekRange());
-
-        return insight;
+        WeeklyAnalysisData data = dataCollector.collectLastWeekData(memberId);
+        validateSkeleton(data);
+        return openAiClient.generateWeeklyInsight(data);
     }
 
-    /**
-     * 특정 주차 데이터 기반 AI 분석 생성
-     */
-    public WeeklyInsightResponse generateWeekInsight(Long memberId, LocalDate weekStart) {
-        log.info("특정 주차 AI 분석 요청 - 회원ID: {}, 주차: {}", memberId, weekStart);
-
-        validateWeekStart(weekStart);
-
-        WeeklyAnalysisData weeklyData = dataCollector.collectWeeklyData(memberId, weekStart);
-
-        validateWeeklyData(weeklyData);
-
-        WeeklyInsightResponse insight = openAiClient.generateWeeklyInsight(weeklyData);
-
-        log.info("특정 주차 AI 분석 완료 - 회원ID: {}, 분석 기간: {}",
-                memberId, insight.getWeekRange());
-
-        return insight;
+    public WeeklyInsightResponse generateSpecificWeekInsight(Long memberId, LocalDate weekStart) {
+        WeeklyAnalysisData data = dataCollector.collectSpecificWeekData(memberId, weekStart);
+        validateSkeleton(data);
+        return openAiClient.generateWeeklyInsight(data);
     }
 
-    /**
-     * 이번주 진행중 데이터 기반 AI 분석 생성 (참고용)
-     */
     public WeeklyInsightResponse generateThisWeekInsight(Long memberId) {
-        log.info("이번주 진행상황 AI 분석 요청 - 회원ID: {}", memberId);
-
-        WeeklyAnalysisData weeklyData = dataCollector.collectThisWeekData(memberId);
-
-        validateWeeklyData(weeklyData);
-
-        WeeklyInsightResponse insight = openAiClient.generateWeeklyInsight(weeklyData);
-
-        log.info("이번주 진행상황 AI 분석 완료 - 회원ID: {}, 분석 기간: {}",
-                memberId, insight.getWeekRange());
-
-        return insight;
+        WeeklyAnalysisData data = dataCollector.collectThisWeekData(memberId);
+        validateSkeleton(data);
+        return openAiClient.generateWeeklyInsight(data);
     }
 
-    /**
-     * 분석 가능한 주차 목록 조회
-     */
-    public List<LocalDate> getAvailableWeeks(Long memberId) {
-        log.debug("분석 가능한 주차 목록 조회 - 회원ID: {}", memberId);
+    public boolean isLastWeekCompleted(Long memberId) {
+        return dataCollector.isLastWeekCompleted(memberId);
+    }
 
+    public java.util.List<String> getAvailableWeeks(Long memberId) {
         return dataCollector.getAvailableWeeks(memberId);
     }
 
-    /**
-     * 현재 시점에서 지난주가 완료되었는지 확인
-     */
-    public boolean isLastWeekCompleted() {
-        LocalDate today = LocalDate.now();
-        DayOfWeek currentDayOfWeek = today.getDayOfWeek();
-
-        // 월요일 이후면 지난주가 완료되었다고 판단
-        return currentDayOfWeek != DayOfWeek.SUNDAY;
-    }
-
-    private void validateWeekStart(LocalDate weekStart) {
-        if (weekStart.getDayOfWeek() != DayOfWeek.MONDAY) {
-            throw new BaseException(ErrorCode.INVALID_WEEK_START);
+    private void validateSkeleton(WeeklyAnalysisData weekly) {
+        if (weekly == null || weekly.getWeekStart() == null || weekly.getWeekEnd() == null) {
+            throw new IllegalStateException("주간 데이터 스켈레톤이 유효하지 않습니다.");
         }
-
-        LocalDate today = LocalDate.now();
-        LocalDate thisMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-
-        if (weekStart.isAfter(thisMonday)) {
-            throw new BaseException(ErrorCode.FUTURE_WEEK_NOT_ALLOWED);
-        }
-    }
-
-    private void validateWeeklyData(WeeklyAnalysisData weeklyData) {
-        if (weeklyData.getDays() == null || weeklyData.getDays().isEmpty()) {
-            throw new BaseException(ErrorCode.NO_WEEKLY_DATA_FOUND);
-        }
-
-        // 최소한의 의미있는 데이터가 있는지 확인
-        boolean hasAnyData = weeklyData.getDays().stream()
-                .anyMatch(day ->
-                        (day.getRoutines() != null && !day.getRoutines().isEmpty()) ||
-                                (day.getNote() != null && !day.getNote().equals("기록 없음"))
-                );
-
-        if (!hasAnyData) {
-            throw new BaseException(ErrorCode.INSUFFICIENT_DATA_FOR_ANALYSIS);
-        }
-
-        log.debug("주간 데이터 검증 완료 - 일수: {}, 분석 기간: {} ~ {}",
-                weeklyData.getDays().size(), weeklyData.getWeekStart(), weeklyData.getWeekEnd());
     }
 }

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyInsightService.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/service/WeeklyInsightService.java
@@ -1,0 +1,143 @@
+package com.groomthon.habiglow.domain.dashboard.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData;
+import com.groomthon.habiglow.domain.dashboard.dto.response.WeeklyInsightResponse;
+import com.groomthon.habiglow.global.exception.BaseException;
+import com.groomthon.habiglow.global.response.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * HabiGlow AI 주간 분석 서비스
+ *
+ * 월~일 7일 주기로 사용자의 습관 데이터를 분석하여
+ * 감정 변화 패턴과 루틴 성공/실패에 대한 공감과 응원 메시지 생성
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WeeklyInsightService {
+
+    private final WeeklyDataCollector dataCollector;
+    private final OpenAiClient openAiClient;
+
+    /**
+     * 지난주 데이터 기반 AI 분석 생성
+     * (이번주 월요일 기준 지난주 월~일)
+     */
+    public WeeklyInsightResponse generateLastWeekInsight(Long memberId) {
+        log.info("지난주 AI 분석 요청 - 회원ID: {}", memberId);
+
+        WeeklyAnalysisData weeklyData = dataCollector.collectLastWeekData(memberId);
+
+        validateWeeklyData(weeklyData);
+
+        WeeklyInsightResponse insight = openAiClient.generateWeeklyInsight(weeklyData);
+
+        log.info("지난주 AI 분석 완료 - 회원ID: {}, 분석 기간: {}",
+                memberId, insight.getWeekRange());
+
+        return insight;
+    }
+
+    /**
+     * 특정 주차 데이터 기반 AI 분석 생성
+     */
+    public WeeklyInsightResponse generateWeekInsight(Long memberId, LocalDate weekStart) {
+        log.info("특정 주차 AI 분석 요청 - 회원ID: {}, 주차: {}", memberId, weekStart);
+
+        validateWeekStart(weekStart);
+
+        WeeklyAnalysisData weeklyData = dataCollector.collectWeeklyData(memberId, weekStart);
+
+        validateWeeklyData(weeklyData);
+
+        WeeklyInsightResponse insight = openAiClient.generateWeeklyInsight(weeklyData);
+
+        log.info("특정 주차 AI 분석 완료 - 회원ID: {}, 분석 기간: {}",
+                memberId, insight.getWeekRange());
+
+        return insight;
+    }
+
+    /**
+     * 이번주 진행중 데이터 기반 AI 분석 생성 (참고용)
+     */
+    public WeeklyInsightResponse generateThisWeekInsight(Long memberId) {
+        log.info("이번주 진행상황 AI 분석 요청 - 회원ID: {}", memberId);
+
+        WeeklyAnalysisData weeklyData = dataCollector.collectThisWeekData(memberId);
+
+        validateWeeklyData(weeklyData);
+
+        WeeklyInsightResponse insight = openAiClient.generateWeeklyInsight(weeklyData);
+
+        log.info("이번주 진행상황 AI 분석 완료 - 회원ID: {}, 분석 기간: {}",
+                memberId, insight.getWeekRange());
+
+        return insight;
+    }
+
+    /**
+     * 분석 가능한 주차 목록 조회
+     */
+    public List<LocalDate> getAvailableWeeks(Long memberId) {
+        log.debug("분석 가능한 주차 목록 조회 - 회원ID: {}", memberId);
+
+        return dataCollector.getAvailableWeeks(memberId);
+    }
+
+    /**
+     * 현재 시점에서 지난주가 완료되었는지 확인
+     */
+    public boolean isLastWeekCompleted() {
+        LocalDate today = LocalDate.now();
+        DayOfWeek currentDayOfWeek = today.getDayOfWeek();
+
+        // 월요일 이후면 지난주가 완료되었다고 판단
+        return currentDayOfWeek != DayOfWeek.SUNDAY;
+    }
+
+    private void validateWeekStart(LocalDate weekStart) {
+        if (weekStart.getDayOfWeek() != DayOfWeek.MONDAY) {
+            throw new BaseException(ErrorCode.INVALID_WEEK_START);
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate thisMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        if (weekStart.isAfter(thisMonday)) {
+            throw new BaseException(ErrorCode.FUTURE_WEEK_NOT_ALLOWED);
+        }
+    }
+
+    private void validateWeeklyData(WeeklyAnalysisData weeklyData) {
+        if (weeklyData.getDays() == null || weeklyData.getDays().isEmpty()) {
+            throw new BaseException(ErrorCode.NO_WEEKLY_DATA_FOUND);
+        }
+
+        // 최소한의 의미있는 데이터가 있는지 확인
+        boolean hasAnyData = weeklyData.getDays().stream()
+                .anyMatch(day ->
+                        (day.getRoutines() != null && !day.getRoutines().isEmpty()) ||
+                                (day.getNote() != null && !day.getNote().equals("기록 없음"))
+                );
+
+        if (!hasAnyData) {
+            throw new BaseException(ErrorCode.INSUFFICIENT_DATA_FOR_ANALYSIS);
+        }
+
+        log.debug("주간 데이터 검증 완료 - 일수: {}, 분석 기간: {} ~ {}",
+                weeklyData.getDays().size(), weeklyData.getWeekStart(), weeklyData.getWeekEnd());
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/util/WeeklyDummyDataGenerator.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/util/WeeklyDummyDataGenerator.java
@@ -1,0 +1,240 @@
+package com.groomthon.habiglow.domain.dashboard.util;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.groomthon.habiglow.domain.daily.entity.DailyReflectionEntity;
+import com.groomthon.habiglow.domain.daily.entity.DailyRoutineEntity;
+import com.groomthon.habiglow.domain.daily.entity.EmotionType;
+import com.groomthon.habiglow.domain.daily.entity.PerformanceLevel;
+import com.groomthon.habiglow.domain.daily.repository.DailyReflectionRepository;
+import com.groomthon.habiglow.domain.daily.repository.DailyRoutineRepository;
+import com.groomthon.habiglow.domain.member.entity.MemberEntity;
+import com.groomthon.habiglow.domain.member.repository.MemberRepository;
+import com.groomthon.habiglow.domain.routine.entity.RoutineEntity;
+import com.groomthon.habiglow.domain.routine.repository.RoutineRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * AI 분석 테스트를 위한 일주일치 더미 데이터 생성기
+ * --spring.profiles.active=dev,dummy-data 로 실행
+ */
+@Slf4j
+@Component
+@Profile("dummy-data")
+@RequiredArgsConstructor
+public class WeeklyDummyDataGenerator implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final RoutineRepository routineRepository;
+    private final DailyReflectionRepository reflectionRepository;
+    private final DailyRoutineRepository dailyRoutineRepository;
+
+    private final Random random = new Random();
+
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+        log.info("=== AI 분석용 더미 데이터 생성 시작 ===");
+
+        // 테스트 사용자 찾기 (없으면 생성)
+        MemberEntity testUser = findOrCreateTestUser();
+        List<RoutineEntity> userRoutines = getUserRoutines(testUser);
+
+        if (userRoutines.isEmpty()) {
+            log.warn("사용자에게 루틴이 없습니다. 먼저 루틴을 생성해주세요.");
+            return;
+        }
+
+        // 지난 주 데이터 생성 (월-일)
+        LocalDate lastMonday = LocalDate.now()
+                .with(TemporalAdjusters.previous(DayOfWeek.MONDAY));
+
+        generateWeeklyData(testUser, userRoutines, lastMonday);
+
+        log.info("=== 더미 데이터 생성 완료 ===");
+        log.info("생성된 기간: {} ~ {}", lastMonday, lastMonday.plusDays(6));
+        log.info("AI 분석 API 테스트 가능합니다: POST /api/dashboard/insight/weekly");
+    }
+
+    private void generateWeeklyData(MemberEntity user, List<RoutineEntity> routines, LocalDate startDate) {
+        for (int day = 0; day < 7; day++) {
+            LocalDate currentDate = startDate.plusDays(day);
+            DayOfWeek dayOfWeek = currentDate.getDayOfWeek();
+
+            log.info("생성 중: {} ({})", currentDate, dayOfWeek);
+
+            // 하루 회고 생성
+            generateDailyReflection(user, currentDate, dayOfWeek);
+
+            // 루틴 기록 생성
+            generateRoutineRecords(user, routines, currentDate, dayOfWeek);
+        }
+    }
+
+    private void generateDailyReflection(MemberEntity user, LocalDate date, DayOfWeek dayOfWeek) {
+        ReflectionPattern pattern = getReflectionPattern(dayOfWeek);
+
+        String content = selectRandom(pattern.reflectionTexts);
+        EmotionType emotion = selectRandom(pattern.emotions);
+
+        DailyReflectionEntity reflection = DailyReflectionEntity.create(user, content, emotion, date);
+        reflectionRepository.save(reflection);
+
+        log.debug("회고 생성: {} - {} ({})", date, content.substring(0, Math.min(20, content.length())), emotion);
+    }
+
+    private void generateRoutineRecords(MemberEntity user, List<RoutineEntity> routines,
+                                        LocalDate date, DayOfWeek dayOfWeek) {
+        PerformancePattern pattern = getPerformancePattern(dayOfWeek);
+
+        int consecutiveDays = 0; // 실제로는 ConsecutiveDaysCalculator에서 계산되지만 더미로 설정
+
+        for (RoutineEntity routine : routines) {
+            PerformanceLevel performance = selectRandom(pattern.performances);
+
+            // 연속일수 더미 계산
+            if (performance == PerformanceLevel.FULL_SUCCESS) {
+                consecutiveDays = random.nextInt(10) + 1; // 1-10일
+            } else {
+                consecutiveDays = 0;
+            }
+
+            DailyRoutineEntity routineRecord = DailyRoutineEntity.create(
+                    routine, user, performance, date, consecutiveDays);
+
+            dailyRoutineRepository.save(routineRecord);
+        }
+
+        log.debug("루틴 기록 생성: {} - {} 개 루틴", date, routines.size());
+    }
+
+    private ReflectionPattern getReflectionPattern(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.SOSO, EmotionType.HAPPY),
+                    Arrays.asList(
+                            "새로운 한 주 시작! 이번엔 꼭 계획대로 해보자",
+                            "월요일이라 좀 무겁지만 의욕은 있어",
+                            "주말이 너무 짧았다... 그래도 화이팅"
+                    )
+            );
+            case TUESDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.SOSO, EmotionType.HAPPY),
+                    Arrays.asList(
+                            "어제보단 리듬이 좀 잡히는 느낌",
+                            "화요일은 그럭저럭 할만한 것 같아",
+                            "월요일 피로가 아직 남아있긴 해"
+                    )
+            );
+            case WEDNESDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.SOSO, EmotionType.SAD),
+                    Arrays.asList(
+                            "벌써 수요일... 시간이 너무 빨라",
+                            "중간 지점이라 그런지 좀 지쳐",
+                            "수요일 고비만 넘으면 될 것 같은데"
+                    )
+            );
+            case THURSDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.SOSO, EmotionType.HAPPY),
+                    Arrays.asList(
+                            "목요일이니까 곧 주말이겠네",
+                            "컨디션 회복되는 느낌이야",
+                            "어제보단 훨씬 나아졌어"
+                    )
+            );
+            case FRIDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.HAPPY, EmotionType.SOSO),
+                    Arrays.asList(
+                            "드디어 금요일! 이번 주도 잘 버텼다",
+                            "마무리 잘하고 주말 맞이하자",
+                            "금요일이라 기분이 좋네"
+                    )
+            );
+            case SATURDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.HAPPY, EmotionType.SOSO),
+                    Arrays.asList(
+                            "주말이라 여유롭긴 한데 루틴은 지켜야지",
+                            "평일보다 느긋하게 보냈어",
+                            "토요일엔 좀 더 재충전하는 시간을 가져야겠어"
+                    )
+            );
+            case SUNDAY -> new ReflectionPattern(
+                    Arrays.asList(EmotionType.SOSO, EmotionType.SAD),
+                    Arrays.asList(
+                            "내일부터 또 한 주가 시작이네...",
+                            "일요일은 항상 아쉬워",
+                            "다음 주 준비하면서 마음 다잡아보자"
+                    )
+            );
+        };
+    }
+
+    private PerformancePattern getPerformancePattern(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> new PerformancePattern(
+                    Arrays.asList(PerformanceLevel.PARTIAL_SUCCESS, PerformanceLevel.FULL_SUCCESS)
+            );
+            case TUESDAY, THURSDAY -> new PerformancePattern(
+                    Arrays.asList(PerformanceLevel.FULL_SUCCESS, PerformanceLevel.PARTIAL_SUCCESS)
+            );
+            case WEDNESDAY -> new PerformancePattern(
+                    Arrays.asList(PerformanceLevel.PARTIAL_SUCCESS, PerformanceLevel.NOT_PERFORMED)
+            );
+            case FRIDAY -> new PerformancePattern(
+                    Arrays.asList(PerformanceLevel.FULL_SUCCESS, PerformanceLevel.PARTIAL_SUCCESS)
+            );
+            case SATURDAY, SUNDAY -> new PerformancePattern(
+                    Arrays.asList(PerformanceLevel.PARTIAL_SUCCESS, PerformanceLevel.FULL_SUCCESS, PerformanceLevel.NOT_PERFORMED)
+            );
+        };
+    }
+
+    private MemberEntity findOrCreateTestUser() {
+        return memberRepository.findByMemberEmail("test@habiglow.com")
+                .orElseGet(() -> {
+                    log.info("테스트 사용자 생성: test@habiglow.com");
+                    MemberEntity testUser = MemberEntity.createSocialMember(
+                            "test@habiglow.com", "테스트유저", null, null, null);
+                    return memberRepository.save(testUser);
+                });
+    }
+
+    private List<RoutineEntity> getUserRoutines(MemberEntity user) {
+        return routineRepository.findByMember_Id(user.getId());
+    }
+
+    private <T> T selectRandom(List<T> items) {
+        return items.get(random.nextInt(items.size()));
+    }
+
+    private static class ReflectionPattern {
+        final List<EmotionType> emotions;
+        final List<String> reflectionTexts;
+
+        ReflectionPattern(List<EmotionType> emotions, List<String> reflectionTexts) {
+            this.emotions = emotions;
+            this.reflectionTexts = reflectionTexts;
+        }
+    }
+
+    private static class PerformancePattern {
+        final List<PerformanceLevel> performances;
+
+        PerformancePattern(List<PerformanceLevel> performances) {
+            this.performances = performances;
+        }
+    }
+}

--- a/src/main/java/com/groomthon/habiglow/domain/dashboard/util/WeeklyDummyDataGenerator.java
+++ b/src/main/java/com/groomthon/habiglow/domain/dashboard/util/WeeklyDummyDataGenerator.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
+import com.groomthon.habiglow.domain.dashboard.dto.WeeklyAnalysisData;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -82,6 +83,58 @@ public class WeeklyDummyDataGenerator implements CommandLineRunner {
             // 루틴 기록 생성
             generateRoutineRecords(user, routines, currentDate, dayOfWeek);
         }
+    }
+
+    public static WeeklyAnalysisData generate(Long memberId, LocalDate weekStart) {
+        LocalDate weekEnd = weekStart.plusDays(6);
+        Random random = new Random();
+        List<WeeklyAnalysisData.DayData> days = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = weekStart.plusDays(i);
+
+            // 감정 이모지 랜덤
+            String[] emojis = {"😀","🙂","😐","☁️"};
+            String emotion = emojis[random.nextInt(emojis.length)];
+
+            // 회고 더미
+            String note = switch (date.getDayOfWeek()) {
+                case MONDAY -> "월요일은 의욕 충만!";
+                case FRIDAY -> "금요일은 행복!";
+                case SUNDAY -> "일요일은 아쉬움";
+                default -> "기록 없음";
+            };
+
+            // 루틴 결과 더미
+            List<WeeklyAnalysisData.RoutineResult> routines = List.of(
+                    WeeklyAnalysisData.RoutineResult.builder()
+                            .name("아침 운동")
+                            .result(pickRandomResult(random))
+                            .build(),
+                    WeeklyAnalysisData.RoutineResult.builder()
+                            .name("물 2L 마시기")
+                            .result(pickRandomResult(random))
+                            .build()
+            );
+
+            days.add(WeeklyAnalysisData.DayData.builder()
+                    .date(date.toString())
+                    .emotion(emotion)
+                    .note(note)
+                    .routines(routines)
+                    .build());
+        }
+
+        return WeeklyAnalysisData.builder()
+                .weekStart(weekStart.toString())
+                .weekEnd(weekEnd.toString())
+                .days(days)
+                .build();
+    }
+
+    private static String pickRandomResult(Random random) {
+        String[] results = {"SUCCESS","PARTIAL","FAIL"};
+        return results[random.nextInt(results.length)];
     }
 
     private void generateDailyReflection(MemberEntity user, LocalDate date, DayOfWeek dayOfWeek) {

--- a/src/main/java/com/groomthon/habiglow/global/response/ApiSuccessCode.java
+++ b/src/main/java/com/groomthon/habiglow/global/response/ApiSuccessCode.java
@@ -28,7 +28,11 @@ public enum ApiSuccessCode implements SuccessType {
 	ROUTINE_VIEW("S211", "루틴 조회 성공"),
 	ROUTINE_UPDATED("S212", "루틴 수정 성공"),
 	ROUTINE_DELETED("S213", "루틴 삭제 성공"),
-	ROUTINE_LIST_VIEW("S214", "루틴 목록 조회 성공");
+	ROUTINE_LIST_VIEW("S214", "루틴 목록 조회 성공"),
+
+	// AI 관련
+	AI_INSIGHT_SUCCESS("S300", "AI 주간 인사이트 조회 성공");
+
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/groomthon/habiglow/global/response/ErrorCode.java
+++ b/src/main/java/com/groomthon/habiglow/global/response/ErrorCode.java
@@ -46,7 +46,13 @@ public enum ErrorCode implements ErrorType {
 	DAILY_RECORD_INVALID_ROUTINES("DAILY004", "유효하지 않은 루틴이 포함되어 있습니다", HttpStatus.BAD_REQUEST.value()),
 
 	// 보안 관련 오류 (SECURITY)
-	TOO_MANY_REQUESTS("SECURITY001", "너무 많은 요청입니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS.value());
+	TOO_MANY_REQUESTS("SECURITY001", "너무 많은 요청입니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS.value()),
+
+	// AI 관련
+	AI_ANALYSIS_FAILED("AI001", "AI 주간 인사이트 분석에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE.value()),
+	AI_RESPONSE_PARSE_FAILED("AI002", "AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+
 
 	private final String code;
 	private final String message;

--- a/src/main/java/com/groomthon/habiglow/global/response/ErrorCode.java
+++ b/src/main/java/com/groomthon/habiglow/global/response/ErrorCode.java
@@ -50,7 +50,14 @@ public enum ErrorCode implements ErrorType {
 
 	// AI 관련
 	AI_ANALYSIS_FAILED("AI001", "AI 주간 인사이트 분석에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE.value()),
-	AI_RESPONSE_PARSE_FAILED("AI002", "AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+	AI_RESPONSE_PARSE_FAILED("AI002", "AI 응답 파싱에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value()),
+
+	// AI 주간 분석 관련 오류
+	INVALID_WEEK_START("WEEKLY001", "주차 시작일은 월요일이어야 합니다.", HttpStatus.BAD_REQUEST.value()),
+	FUTURE_WEEK_NOT_ALLOWED("WEEKLY002", "미래 주차 데이터는 분석할 수 없습니다.", HttpStatus.BAD_REQUEST.value()),
+	NO_WEEKLY_DATA_FOUND("WEEKLY003", "해당 주차에 기록된 데이터가 없습니다.", HttpStatus.NOT_FOUND.value()),
+	INSUFFICIENT_DATA_FOR_ANALYSIS("WEEKLY004", "분석에 필요한 충분한 데이터가 없습니다.", HttpStatus.BAD_REQUEST.value());
+
 
 
 

--- a/src/main/java/com/groomthon/habiglow/global/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/com/groomthon/habiglow/global/swagger/SwaggerResponseDescription.java
@@ -70,7 +70,18 @@ public enum SwaggerResponseDescription {
 		ErrorCode.INTERNAL_SERVER_ERROR,
 		ErrorCode.INVALID_INPUT_VALUE,
 		ErrorCode.PARAMETER_VALIDATION_ERROR
+	)),
+
+	// AI 관련 에러
+	AI_ANALYSIS_ERROR(Set.of(
+			ErrorCode.INVALID_WEEK_START,
+			ErrorCode.FUTURE_WEEK_NOT_ALLOWED,
+			ErrorCode.NO_WEEKLY_DATA_FOUND,
+			ErrorCode.INSUFFICIENT_DATA_FOR_ANALYSIS,
+			ErrorCode.AI_ANALYSIS_FAILED,
+			ErrorCode.AI_RESPONSE_PARSE_FAILED
 	));
+
 
 	private final Set<ErrorCode> errorCodeList;
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,6 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -14,6 +13,15 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+# OpenAI 설정
+openai:
+  api:
+    key: ${OPENAI_API_KEY:your-dev-api-key-here}
+    base-url: https://api.openai.com/v1
+    model: gpt-4o-mini
+    timeout: 30s
+    max-retries: 3
 
 # 개발환경 쿠키 설정
 cookie:
@@ -30,4 +38,6 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql.BasicBinder: trace
-    com.example.login: debug
+    com.groomthon.habiglow: debug
+    # OpenAI API 호출 로깅용
+    org.springframework.web.reactive.function.client: debug

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,15 @@ spring:
       hibernate:
         format_sql: false
 
+# OpenAI 설정 (운영환경)
+openai:
+  api:
+    key: ${OPENAI_API_KEY}
+    base-url: https://api.openai.com/v1
+    model: gpt-4o-mini
+    timeout: 30s
+    max-retries: 3
+
 cookie:
   secure: true
 
@@ -29,5 +38,6 @@ logging:
   level:
     org.hibernate.SQL: warn
     org.hibernate.type.descriptor.sql.BasicBinder: warn
-    com.example.login: info
+    com.groomthon.habiglow: info
+    org.springframework.web.reactive.function.client: warn
     root: warn

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: dev
+    active: dev,dummy-data
   config:
     import:
       - optional:file:.env[.properties]


### PR DESCRIPTION
## 요약
- 대시보드 주간 인사이트 수집 로직을 **하이브리드**로 전환
  - **실데이터 우선**, **없으면 더미**(지난주에 한해)
  - 더미 프로필(`dummy-data`)이 활성화되어도 **실데이터가 들어오면 즉시 반영**
  - `/available-weeks`에서 **지난주 더미 주차는 초기값으로 항상 유지**(실데이터가 생겨도 사라지지 않음)

## 변경 사항
- `DashboardController`
  - Swagger 태그/설명 추가(`@Tag`, `@SecurityRequirement`)
  - `/insight/weekly/specific`에서 **지난주가 아니고 실데이터 없으면 204 No Content** 처리
- `WeeklyInsightService`
  - 실데이터 존재 여부 확인용 메서드 추가(`hasRealWeekData`)
- `WeeklyDataCollector`
  - 실데이터 존재 검사: `DailyReflectionRepository.findByMemberIdAndReflectionDate(...)` 단건 조회를 **7일 루프**로 판단 (daily 코드 변경 없음)
  - `/available-weeks`: 최근 12주 스캔으로 실주차 수집 + 더미 프로필일 때 지난주 더미 주차 항상 포함
  - `/weekly/last`·`/weekly/specific` 하이브리드 분기 로직 구현
  - `/weekly/current`은 더미 미적용(실데이터만)

## 엔드포인트 동작(최종)
- `POST /api/dashboard/insight/weekly/last`
  - 지난주 **실데이터 있으면 실데이터**, 없으면 **더미**(dummy-data 프로필 활성화 시)
- `POST /api/dashboard/insight/weekly/specific?weekStart=YYYY-MM-DD`
  - `weekStart`가 지난주 시작일: 위 규칙과 동일(실우선/없으면 더미)
  - 그 외: **실데이터 없으면 204 No Content**, 있으면 분석 생성
- `POST /api/dashboard/insight/weekly/current`
  - 실데이터만. 없으면 스켈레톤으로 AI 호출(더미 X)
- `GET /api/dashboard/insight/last-week-completed`
  - dummy 프로필이면 **항상 true**, 아니면 지난주 실데이터 존재 여부
- `GET /api/dashboard/insight/available-weeks`
  - **최근 12주 실주차 + (dummy 프로필일 때) 지난주 더미 주차**(초기값 유지)

## 변경 파일
- `domain/dashboard/controller/DashboardController.java`
- `domain/dashboard/service/WeeklyInsightService.java`
- `domain/dashboard/service/WeeklyDataCollector.java`
- (참고) 더미 제너레이터: `domain/dashboard/util/WeeklyDummyDataGenerator.java` **변경 없음**

## 구성/환경
- 프로필:
  - 개발/데모: `SPRING_PROFILES_ACTIVE=dev,dummy-data`
  - 운영 기본: `SPRING_PROFILES_ACTIVE=prod` (데모 필요 시에만 `prod,dummy-data`)
- 인증:
  - Swagger 테스트 시 **Authorize → Bearer <access_token>** 입력 필수
- OpenAI:
  - `OpenAiClient.generateWeeklyInsight(...)` 사용. 키 미설정 시 500 발생 가능 → 필요 시 스텁 허용

## 테스트 시나리오 (Swagger)
1. `dummy-data` 활성화 + 지난주 실데이터 없음  
   - `/weekly/last` → 더미 분석 반환(200)  
   - `/available-weeks` → `[<지난주 범위>]` 포함  
   - `/last-week-completed` → `true`
2. `dummy-data` 활성화 + 지난주 실데이터 일부 생성  
   - `/weekly/last` → **실데이터 분석**(더미 아닌 값)  
   - `/available-weeks` → **지난주 더미 주차 유지 + 실주차들 추가**
3. `dummy-data` 비활성화 + 임의 주차 실데이터 없음  
   - `/weekly/specific?weekStart=<지난주 아님>` → **204 No Content**
4. `dummy-data` 비활성화 + 이번주 실데이터 없음  
   - `/weekly/current` → 스켈레톤 분석(200)

## 호환성/마이그레이션
- **Daily 영역 코드/리포지토리 변경 없음**
- DB 스키마 변경 없음
- API 스펙 변경 없음(단, `/weekly/specific`에 **204 No Content** 추가)

## 리스크 & 완화
- OpenAI 호출 실패 시 500 → 키/네트워크 확인 또는 스텁 적용
- 최근 12주만 available-weeks 스캔 → 과거 무제한 필요 시 추후 리포 확장

## 체크리스트
- [x] Swagger `bearerAuth` 등록 및 엔드포인트 수동 테스트 완료  
- [x] dummy 프로필 on/off 각각 시나리오 검증  
- [x] `/weekly/specific` 204 동작 확인  
- [x] 운영 프로필에서 dummy 프로필 비활성화 확인(기본 prod)

## 스크린샷/로그(선택)
<img width="587" height="343" alt="image" src="https://github.com/user-attachments/assets/d0ee0616-cc77-46ea-b679-8c3551c0651c" />

